### PR TITLE
Shift to simple server

### DIFF
--- a/rust/run.sh
+++ b/rust/run.sh
@@ -21,4 +21,4 @@ do
 done
 
 export RUST_LOG=discv5=debug
-exec ~vagrant/discv5/target/debug/examples/find_nodes 192.168.3.51 $port true $bootnode
+exec ~vagrant/discv5/target/debug/examples/simple_server 192.168.3.51 $port $bootnode

--- a/rust/setup.sh
+++ b/rust/setup.sh
@@ -16,4 +16,4 @@ fi
 
 # build it
 cd discv5
-cargo build --example find_nodes
+cargo build --example simple_server


### PR DESCRIPTION
Shifts the rust example to use a more simple example for testing. 

There still seems to be some discrepancies, but I'm not sure what results the tests are expecting.

Things appear to behaving on the rust side as I'd expect, but potentially missing something. 
